### PR TITLE
Enable deploying gh pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,60 @@
+name: Publish Github Pages
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  gh-pages-main:
+    name: Publish main
+    runs-on: ubuntu-20.04
+
+    permissions:
+      actions: write
+      checks: write
+      repository-projects: read
+
+    steps:
+    - name: Setup locale
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo update-locale
+    - name: Checkout source code
+      uses: actions/checkout@master
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build main
+      run: npm run build
+    
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages-main
+
+  gh-pages-storybook:
+    name: Publish storybook
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Setup locale
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo update-locale
+    - name: Checkout source code
+      uses: actions/checkout@master
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build storybook
+      run: npm build-storybook
+    
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages-storybook
+  

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# storybook
+/storybook-static


### PR DESCRIPTION
Enable Github Action that deploys storybook and main to gh-pages branch

### 요구 사항
- [] `dev` 브랜치에 코드 반영시 `gh-pages`에 웹 배포
- [] 'dev' 브랜치에 코드 반영시 `gh-pages-storybook`에 스토리북 배포

### 수정 내역
- Add workflows
- Add `/storybook-static` to `.gitignore`

### 당부의 말씀

### 테스트 결과

