### PR TITLE
fix: TabList style 수정

### DIFF
--- a/src/components/TabList/TabList.scss
+++ b/src/components/TabList/TabList.scss
@@ -22,9 +22,18 @@
 
   &__item {
     padding: 3px 12px;
-    margin-right: 8px;
+    margin: 0px 4px;
     font-size: 16px;
     line-height: 44px;
+
+    &:first-of-type {
+      margin-left: 0px;
+      margin-right: 4px;
+    }
+    &:last-of-type {
+      margin-left: 4px;
+      margin-right: 0px;
+    }
 
     &.round {
       color: $black-8B;

--- a/src/components/TabList/TabList.scss
+++ b/src/components/TabList/TabList.scss
@@ -21,6 +21,8 @@
   }
 
   &__item {
+    display: flex;
+    flex-shrink: 0;
     padding: 3px 12px;
     margin: 0px 4px;
     font-size: 16px;

--- a/src/components/TabList/TabList.scss
+++ b/src/components/TabList/TabList.scss
@@ -22,7 +22,7 @@
 
   &__item {
     padding: 3px 12px;
-    margin: 0px 4px;
+    margin-right: 8px;
     font-size: 16px;
     line-height: 44px;
 


### PR DESCRIPTION
### 요구 사항
디자인의 수정 사항을 공유드립니다
![image](https://user-images.githubusercontent.com/50590025/188937189-9b3fe6e5-5f38-4ab0-b96b-dddb87f229c9.png)
![image](https://user-images.githubusercontent.com/50590025/188937240-d62ff77d-e202-4582-b910-3c1375f9b259.png)

트레이너 리스트 페이지에서 TabList(전체 트레이너)는 부모로부터 24px, TopDownFilter(최신순)은 부모로부터 30px 왼쪽으로 떨어져있습니다.
![before](https://user-images.githubusercontent.com/50590025/188937439-c72ffae7-1faf-4421-9c42-5972de74724b.PNG)

TabList(전체 트레이너)에 `margin-left: 24px`를 주게 되면 컴포넌트의 `margin: 0px 4px`로 왼쪽으로 **28px**로 설정이 되어 위치가 유사하게 되는 문제가 있습니다. 
![after](https://user-images.githubusercontent.com/50590025/188937805-8d1c7fa5-9183-4602-9306-fc1a41056cd1.PNG)

~~이를 양쪽 4px이 아닌 오른쪽 8px로 변경을 하려 합니다. 이때 컴포넌트가 **양쪽 `4px`을 유지해야 하는 이유**가 있으면 페이지에서 `24px`을 주지 않고 `20px`을 주려 하는데요, 어떻게 생각하시나요??~~

### 최종 수정 내역
1. 처음과 마지막은 한쪽에 4px, 나머지는 양쪽에 4px로 설정
![image](https://user-images.githubusercontent.com/50590025/190902949-33fca042-a527-41fe-b3f5-e185971b6783.png)
![image](https://user-images.githubusercontent.com/50590025/190902968-7b7c6f0c-0818-4470-a645-8057c8bf96d6.png)
![image](https://user-images.githubusercontent.com/50590025/190902998-33a21798-9b35-4997-a20b-cc6dfb9b5a92.png)

2. 화면 크기에 따라 스크롤이 안되는 문제 수정
![image](https://user-images.githubusercontent.com/50590025/190902895-5fda4982-cf4c-435b-8728-4293996baa5b.png)

