### PR TITLE
Entry 페이지 로고 위치 수정

### DIFF
--- a/src/pages/Entry/Entry.module.scss
+++ b/src/pages/Entry/Entry.module.scss
@@ -11,7 +11,7 @@
 
 .logo {
   flex-grow: 1;
-  padding-top: 50%;
+  padding-top: 35vh;
   
   & > * {
     width: 164px;


### PR DESCRIPTION
### 요구 사항
- 화면 넓이에 따라 로고 위치 변경됨 -> 고정

### 수정 내역
|화면 좁을 때|화면 넓을 때|
|---|---|
|![image](https://user-images.githubusercontent.com/37607649/195999171-95e7f36a-175b-4cd1-9198-d794595b8422.png)|![image](https://user-images.githubusercontent.com/37607649/195999206-6fe44972-6b0f-4f1f-9b30-8498510c9edd.png)|

### 당부의 말씀
- 로고 위의 공백값 수정 입니다.

### 테스트 결과
