### PR TITLE
[API] AUTH API 호출 함수 추가 및 로그인 mock 스토리북 제작

### DIFF
--- a/src/common/apis/auth/index.ts
+++ b/src/common/apis/auth/index.ts
@@ -1,0 +1,3 @@
+export * from "./signOut";
+export * from "./signIn";
+export * from "./refreshToken";

--- a/src/common/apis/auth/refreshToken.ts
+++ b/src/common/apis/auth/refreshToken.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+import { resultData } from "../../configs/axios";
+import { apiUrls } from "../utils";
+
+export type RefreshTokenBody = {
+  refreshToken: string;
+};
+
+export type RefreshTokenResponse = {
+  accessToken: string;
+};
+
+export const refreshToken = (body: RefreshTokenBody) => {
+  return resultData<RefreshTokenResponse>(
+    axios.post(apiUrls.auth.refreshToken(), body)
+  );
+};

--- a/src/common/apis/auth/signIn.ts
+++ b/src/common/apis/auth/signIn.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+import { resultData } from "../../configs/axios";
+import { apiUrls } from "../utils";
+
+export type SignInBody = {
+  email: string;
+  password: string;
+};
+
+export type SignInResponse = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export const signIn = (body: SignInBody) => {
+  return resultData<SignInResponse>(axios.post(apiUrls.auth.signIn(), body));
+};

--- a/src/common/apis/auth/signOut.ts
+++ b/src/common/apis/auth/signOut.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+import { resultData } from "../../configs/axios";
+import { apiUrls } from "../utils";
+
+export const signOut = () => {
+  return resultData<null>(axios.post(apiUrls.auth.signOut()));
+};

--- a/src/common/apis/utils/apiUrls.ts
+++ b/src/common/apis/utils/apiUrls.ts
@@ -4,4 +4,9 @@ export const apiUrls = {
   test: {
     getSample: () => `${BASE_URL}/sample`,
   },
+  auth: {
+    signIn: () => `${BASE_URL}/auth/login`,
+    refreshToken: () => `${BASE_URL}/auth/refresh`,
+    signOut: () => `${BASE_URL}/auth/logout`,
+  },
 };

--- a/src/components/Input/Input.view.tsx
+++ b/src/components/Input/Input.view.tsx
@@ -5,6 +5,7 @@ import styles from "./Input.module.scss";
 export interface Props {
   label?: string;
   placeholder?: string;
+  name?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   confirmMessage?: string;
@@ -15,6 +16,7 @@ export interface Props {
 const Input = ({
   label,
   placeholder,
+  name,
   value,
   onChange,
   confirmMessage,
@@ -25,7 +27,12 @@ const Input = ({
     <div className={styles.container}>
       <div className={styles.label}>{label}</div>
       <div className={styles.input}>
-        <input value={value} placeholder={placeholder} onChange={onChange} />
+        <input
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          onChange={onChange}
+        />
         {onReset && value && <GreyDeleteCircle className={styles.icon} />}
       </div>
       <div className={styles.confirm}>{confirmMessage}</div>

--- a/src/pages/SignIn/SignIn.stories.tsx
+++ b/src/pages/SignIn/SignIn.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta } from "@storybook/react";
+import { buildStory } from "../../common/configs/storybook";
+import * as mswHandlers from "./mocks/mswHandler";
+import SignIn from "./SignIn";
+
+export default {
+  title: "Pages/SignIn/mocks",
+  component: SignIn,
+} as Meta;
+
+const Template = () => <SignIn />;
+
+export const 성공 = buildStory(Template, { mswHandlers: mswHandlers.성공 });
+
+export const 실패 = buildStory(Template, { mswHandlers: mswHandlers.실패 });

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,7 +1,36 @@
+import { useState } from "react";
+import { signIn } from "../../common/apis/auth";
 import SignInView from "./SignIn.view";
 
 const SignIn = () => {
-  return <SignInView />;
+  const [data, setData] = useState<{ email: string; password: string }>({
+    email: "",
+    password: "",
+  });
+
+  const onClickConfirm = () => {
+    signIn(data)
+      .then(() => {
+        alert("TODO: 로그인 성공");
+      })
+      .catch(() => {
+        alert("TODO: 로그인 실패");
+      });
+  };
+
+  return (
+    <SignInView
+      data={data}
+      onChange={(e) => {
+        const { name, value } = e.target;
+
+        setData({ ...data, [name]: value });
+      }}
+      onClickConfirm={onClickConfirm}
+      // TODO: 비활성화 조건 추가
+      isDisabledButton={!data.email || !data.password}
+    />
+  );
 };
 
 export default SignIn;

--- a/src/pages/SignIn/SignIn.view.stories.tsx
+++ b/src/pages/SignIn/SignIn.view.stories.tsx
@@ -2,9 +2,11 @@ import { Meta } from "@storybook/react";
 import SignIn, { Props } from "./SignIn.view";
 
 export default {
-  title: "Pages/SignIn",
+  title: "Pages/SignIn/views",
   component: SignIn,
-  args: {},
+  args: {
+    data: { email: "", password: "" },
+  },
 } as Meta;
 
 const Template = (args: Props) => <SignIn {...args} />;

--- a/src/pages/SignIn/SignIn.view.tsx
+++ b/src/pages/SignIn/SignIn.view.tsx
@@ -3,11 +3,18 @@ import Input from "../../components/Input";
 import styles from "./SignIn.module.scss";
 
 export interface Props {
+  data: { email: string; password: string };
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isDisabledButton?: boolean;
   onClickConfirm?: () => void;
 }
 
-const SignInView = ({ isDisabledButton, onClickConfirm }: Props) => {
+const SignInView = ({
+  data,
+  onChange,
+  isDisabledButton,
+  onClickConfirm,
+}: Props) => {
   return (
     <div className={styles.container}>
       {/* TODO: 헤더 추가하기 */}
@@ -19,8 +26,17 @@ const SignInView = ({ isDisabledButton, onClickConfirm }: Props) => {
         onClick={onClickConfirm}
       >
         <div className={styles.inputGroup}>
-          <Input label="아이디(이메일)" placeholder="groove@groove.com" />
           <Input
+            name="email"
+            value={data.email}
+            onChange={onChange}
+            label="아이디(이메일)"
+            placeholder="groove@groove.com"
+          />
+          <Input
+            name="password"
+            value={data.password}
+            onChange={onChange}
             label="비밀번호"
             placeholder="영문, 숫자, 특수문자 조합 8자리 이상"
           />

--- a/src/pages/SignIn/mocks/mockApi.ts
+++ b/src/pages/SignIn/mocks/mockApi.ts
@@ -1,0 +1,32 @@
+import { rest } from "msw";
+import { SignInResponse } from "../../../common/apis/auth";
+import { apiUrls } from "../../../common/apis/utils";
+import { ApiResponseData } from "../../../common/configs/axios";
+
+export const 로그인 = {
+  성공: rest.post(apiUrls.auth.signIn(), (_, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json<ApiResponseData<SignInResponse>>({
+        result: "SUCCESS",
+        data: {
+          accessToken: "__ACCESS_TOKEN__",
+          refreshToken: "__REFRESH_TOKEN__",
+        },
+      })
+    );
+  }),
+  실패: rest.post(apiUrls.auth.signIn(), (_, res, ctx) => {
+    return res(
+      ctx.status(500),
+      ctx.json<ApiResponseData<SignInResponse>>({
+        result: "ERROR",
+        error: {
+          code: "400",
+          message: "로그인 실패",
+          data: {},
+        },
+      })
+    );
+  }),
+};

--- a/src/pages/SignIn/mocks/mswHandler.ts
+++ b/src/pages/SignIn/mocks/mswHandler.ts
@@ -1,0 +1,5 @@
+import { 로그인 } from "./mockApi";
+
+export const 성공 = [로그인.성공];
+
+export const 실패 = [로그인.실패];


### PR DESCRIPTION
### 요구 사항
- auth API 호출 함수 추가
- 로그인 화면 내 api 호출
- 로그인 API mock 함수 추가 + 스토리북 제작

### 수정 내역

### 당부의 말씀
- 확정된 API는 auth 밖에 없는 것 같아 먼저 제작하였습니다.

### 테스트 결과
- 스토리북에서 정상 동작합니다.
